### PR TITLE
Unquote doesn't handle string literals with newlines in them. For str…

### DIFF
--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1582,3 +1582,18 @@ func TestUnmarshalAnonymousIsNotStruct(t *testing.T) {
 	assert.Equal(t, "String A", m.Strings[0].TheString)
 	assert.Equal(t, "String B", m.Strings[1].TheString)
 }
+
+func TestUnmarshalNonLiteralString(t *testing.T) {
+	input := `[{"article":"
+		newlines are invalid.
+		They're not string \"literals\".
+	"}]`
+
+	var articles []struct {
+		Article string `json:"article"`
+	}
+
+	Unmarshal([]byte(input), &articles)
+
+	assert.Equal(t, "\n\t\tnewlines are invalid.\n\t\tThey're not string \"literals\".\n\t", articles[0].Article)
+}


### PR DESCRIPTION
…ings that are quoted but contain newlines (such as HTML), we still need to remove the surrounding quotes and un-escape any quotes in the string. We now do this manually if Unquote fails.